### PR TITLE
Add biocViews

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,4 @@ Encoding: UTF-8
 Imports: RobustRankAggreg, topGO, clusterProfiler, ReactomePA, dplyr, ggplot2, org.Mm.eg.db, methods
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2
+biocViews: GeneExpression, GeneSetEnrichment, GraphAndNetwork, GO, KEGG


### PR DESCRIPTION
Adding biocViews has two purposes:

1. If this pkg ever reaches bioconductor then it will appear in some relevant bioconductor views already. Right now it may not be important but having the views is not harmful anyway.

2. `remotes::install_github()` can install pkgs from GitHub. The `remotes` pkg guesses if the package being installed requires access to the Bioconductor repositories by checking if the package being installed has the biocViews field in the DESCRIPTION file. By adding this field we make it easy to install the package using `remotes`

https://github.com/r-lib/remotes/blob/b9091cc471ea59471d10981330a868402e1b7bd9/install-github.R#L6082

https://github.com/r-lib/remotes/blob/b9091cc471ea59471d10981330a868402e1b7bd9/install-github.R#L687-L694